### PR TITLE
#101 Fixing bug with string `@language` tag support.

### DIFF
--- a/src/main/scala/csvwcheck/PropertyChecker.scala
+++ b/src/main/scala/csvwcheck/PropertyChecker.scala
@@ -52,32 +52,39 @@ object PropertyChecker {
   private val NameRegExp =
     "^([A-Za-z0-9]|(%[A-F0-9][A-F0-9]))([A-Za-z0-9_]|(%[A-F0-9][A-F0-9]))*$".r
   private val Properties = Map(
-    "@language" -> languageProperty(PropertyType.Context),
     // Context Properties
+    "@language" -> languageProperty(PropertyType.Context),
     "@base" -> linkProperty(PropertyType.Context),
     // common properties
     "@id" -> linkProperty(PropertyType.Common),
+    "dialect" -> dialectProperty(PropertyType.Common),
     "notes" -> notesProperty(PropertyType.Common),
     "suppressOutput" -> booleanProperty(PropertyType.Common),
-    "null" -> nullProperty(PropertyType.Inherited),
-    "separator" -> separatorProperty(PropertyType.Inherited),
-    "lang" -> languageProperty(PropertyType.Inherited),
-    "default" -> stringProperty(PropertyType.Inherited),
-    "required" -> booleanProperty(PropertyType.Inherited),
-    "ordered" -> booleanProperty(PropertyType.Inherited),
+    // Inherited properties
+    "aboutUrl" -> uriTemplateProperty(PropertyType.Inherited),
     "datatype" -> datatypeProperty(PropertyType.Inherited),
+    "default" -> stringProperty(PropertyType.Inherited),
+    "lang" -> languageProperty(PropertyType.Inherited),
+    "null" -> nullProperty(PropertyType.Inherited),
+    "ordered" -> booleanProperty(PropertyType.Inherited),
+    "propertyUrl" -> uriTemplateProperty(PropertyType.Inherited),
+    "required" -> booleanProperty(PropertyType.Inherited),
+    "separator" -> separatorProperty(PropertyType.Inherited),
+    "textDirection" -> textDirectionProperty(PropertyType.Inherited),
+    "valueUrl" -> uriTemplateProperty(PropertyType.Inherited),
+    // Table properties
     "tableSchema" -> tableSchemaProperty(PropertyType.Table),
     "transformations" -> transformationsProperty(PropertyType.Table),
-    "aboutUrl" -> uriTemplateProperty(PropertyType.Inherited),
-    "propertyUrl" -> uriTemplateProperty(PropertyType.Inherited),
-    "valueUrl" -> uriTemplateProperty(PropertyType.Inherited),
-    "textDirection" -> textDirectionProperty(PropertyType.Inherited),
-    "dialect" -> dialectProperty(PropertyType.Common),
+    "url" -> linkProperty(PropertyType.Table),
+    // Schema Properties
+    "columns" -> columnsProperty(PropertyType.Schema),
+    "foreignKeys" -> foreignKeysProperty(PropertyType.Schema),
+    "primaryKey" -> columnReferenceProperty(PropertyType.Schema),
+    "rowTitles" -> columnReferenceProperty(PropertyType.Schema),
     // Column level properties
+    "name" -> nameProperty(PropertyType.Column),
     "titles" -> naturalLanguageProperty(PropertyType.Column),
     "virtual" -> booleanProperty(PropertyType.Column),
-    "name" -> nameProperty(PropertyType.Column),
-    "url" -> linkProperty(PropertyType.Table),
     // Dialect Properties
     "commentPrefix" -> stringProperty(PropertyType.Dialect),
     "delimiter" -> stringProperty(PropertyType.Dialect),
@@ -92,15 +99,10 @@ object PropertyChecker {
     "skipInitialSpace" -> booleanProperty(PropertyType.Dialect),
     "skipRows" -> numericProperty(PropertyType.Dialect),
     "trim" -> trimProperty(PropertyType.Dialect),
-    // Schema Properties
-    "columns" -> columnsProperty(PropertyType.Schema),
-    "primaryKey" -> columnReferenceProperty(PropertyType.Schema),
-    "foreignKeys" -> foreignKeysProperty(PropertyType.Schema),
-    "rowTitles" -> columnReferenceProperty(PropertyType.Schema),
     // Transformation properties
-    "targetFormat" -> targetFormatProperty(PropertyType.Transformation),
     "scriptFormat" -> scriptFormatProperty(PropertyType.Transformation),
     "source" -> sourceProperty(PropertyType.Transformation),
+    "targetFormat" -> targetFormatProperty(PropertyType.Transformation),
     // Foreign Key Properties
     "columnReference" -> columnReferenceProperty(PropertyType.ForeignKey),
     "reference" -> referenceProperty(PropertyType.ForeignKey),
@@ -1191,15 +1193,15 @@ object PropertyChecker {
                   throw MetadataError("@type of dialect is not 'Dialect'")
                 }
               case _ =>
-                val (newValue, w, t) = checkProperty(key, v, baseUrl, lang)
-                if (t == PropertyType.Dialect && w.isEmpty) {
+                val (newValue, propertyWarnings, propertyType) = checkProperty(key, v, baseUrl, lang)
+                if (propertyType == PropertyType.Dialect && propertyWarnings.isEmpty) {
                   valueCopy.set(key, newValue)
                 } else {
                   valueCopy.remove(key)
-                  if (t != PropertyType.Dialect) {
+                  if (propertyType != PropertyType.Dialect) {
                     warnings = warnings :+ "invalid_property"
                   }
-                  warnings = Array.concat(warnings, w)
+                  warnings = Array.concat(warnings, propertyWarnings)
                 }
             }
           }

--- a/src/main/scala/csvwcheck/PropertyChecker.scala
+++ b/src/main/scala/csvwcheck/PropertyChecker.scala
@@ -1546,10 +1546,10 @@ object PropertyChecker {
     if (valueCopy.path("@value").isMissingNode) {
       throw MetadataError("common property with @language lacks a @value")
     }
-    val matcher = Bcp47Language.r.pattern.matcher(v.asText())
-    if (!matcher.matches() || v.isEmpty) {
+    val language = v.asText()
+    if (language.isEmpty || !Bcp47Language.r.matches(language)) {
       throw MetadataError(
-        s"common property has invalid @language (${v.asText()})"
+        s"common property has invalid @language (${language})"
       )
     }
   }

--- a/src/test/resources/csvwExamples/languagetagbroken101/goverment-year.csv
+++ b/src/test/resources/csvwExamples/languagetagbroken101/goverment-year.csv
@@ -1,0 +1,12 @@
+Uri Identifier,Label,Notation,Parent Uri Identifier,Sort Priority,Description,Original Concept URI
+2011-2012,2011-2012,2011-2012,,0,,http://reference.data.gov.uk/id/government-year/2011-2012
+2012-2013,2012-2013,2012-2013,,1,,http://reference.data.gov.uk/id/government-year/2012-2013
+2013-2014,2013-2014,2013-2014,,2,,http://reference.data.gov.uk/id/government-year/2013-2014
+2014-2015,2014-2015,2014-2015,,3,,http://reference.data.gov.uk/id/government-year/2014-2015
+2015-2016,2015-2016,2015-2016,,4,,http://reference.data.gov.uk/id/government-year/2015-2016
+2016-2017,2016-2017,2016-2017,,5,,http://reference.data.gov.uk/id/government-year/2016-2017
+2017-2018,2017-2018,2017-2018,,6,,http://reference.data.gov.uk/id/government-year/2017-2018
+2018-2019,2018-2019,2018-2019,,7,,http://reference.data.gov.uk/id/government-year/2018-2019
+2019-2020,2019-2020,2019-2020,,8,,http://reference.data.gov.uk/id/government-year/2019-2020
+2020-2021,2020-2021,2020-2021,,9,,http://reference.data.gov.uk/id/government-year/2020-2021
+2021-2022,2021-2022,2021-2022,,10,,http://reference.data.gov.uk/id/government-year/2021-2022

--- a/src/test/resources/csvwExamples/languagetagbroken101/goverment-year.csv-metadata.json
+++ b/src/test/resources/csvwExamples/languagetagbroken101/goverment-year.csv-metadata.json
@@ -1,0 +1,64 @@
+{
+    "@context": "http://www.w3.org/ns/csvw",
+    "@id": "goverment-year.csv#code-list",
+    "url": "goverment-year.csv",
+    "tableSchema": "goverment-year.table.json",
+    "rdfs:seeAlso": [
+        {
+            "@id": "goverment-year.csv#csvcubed-build-activity",
+            "@type": [
+                "http://www.w3.org/ns/prov#Activity",
+                "http://www.w3.org/2000/01/rdf-schema#Resource"
+            ],
+            "http://www.w3.org/ns/prov#used": [
+                {
+                    "@id": "https://github.com/GSS-Cogs/csvcubed/releases/tag/v0.3.2"
+                }
+            ]
+        },
+        {
+            "@id": "goverment-year.csv#code-list",
+            "@type": [
+                "http://www.w3.org/ns/dcat#Dataset",
+                "http://www.w3.org/2000/01/rdf-schema#Resource",
+                "http://www.w3.org/ns/dcat#Resource",
+                "http://www.w3.org/ns/prov#Entity",
+                "http://www.w3.org/2004/02/skos/core#ConceptScheme"
+            ],
+            "http://purl.org/dc/terms/identifier": [
+                {
+                    "@value": "Goverment Year"
+                }
+            ],
+            "http://purl.org/dc/terms/issued": [
+                {
+                    "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
+                    "@value": "2023-03-31T12:10:55.672749"
+                }
+            ],
+            "http://purl.org/dc/terms/modified": [
+                {
+                    "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
+                    "@value": "2023-03-31T12:10:55.672749"
+                }
+            ],
+            "http://purl.org/dc/terms/title": [
+                {
+                    "@language": "en",
+                    "@value": "Goverment Year"
+                }
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#label": [
+                {
+                    "@language": "en",
+                    "@value": "Goverment Year"
+                }
+            ],
+            "http://www.w3.org/ns/prov#wasGeneratedBy": [
+                {
+                    "@id": "goverment-year.csv#csvcubed-build-activity"
+                }
+            ]
+        }
+    ]
+}

--- a/src/test/resources/csvwExamples/languagetagbroken101/goverment-year.table.json
+++ b/src/test/resources/csvwExamples/languagetagbroken101/goverment-year.table.json
@@ -1,0 +1,65 @@
+{
+    "columns": [
+        {
+            "titles": "Uri Identifier",
+            "name": "uri_identifier",
+            "required": true,
+            "suppressOutput": true
+        },
+        {
+            "titles": "Label",
+            "name": "label",
+            "required": true,
+            "propertyUrl": "rdfs:label"
+        },
+        {
+            "titles": "Notation",
+            "name": "notation",
+            "required": true,
+            "propertyUrl": "skos:notation"
+        },
+        {
+            "titles": "Parent Uri Identifier",
+            "name": "parent_uri_identifier",
+            "required": false,
+            "propertyUrl": "skos:broader",
+            "valueUrl": "goverment-year.csv#{+parent_uri_identifier}"
+        },
+        {
+            "titles": "Sort Priority",
+            "name": "sort_priority",
+            "required": false,
+            "datatype": "integer",
+            "propertyUrl": "http://www.w3.org/ns/ui#sortPriority"
+        },
+        {
+            "titles": "Description",
+            "name": "description",
+            "required": false,
+            "propertyUrl": "rdfs:comment"
+        },
+        {
+            "titles": "Original Concept URI",
+            "name": "uri",
+            "required": true,
+            "propertyUrl": "owl:sameAs",
+            "valueUrl": "{+uri}"
+        },
+        {
+            "virtual": true,
+            "name": "virt_inScheme",
+            "required": true,
+            "propertyUrl": "skos:inScheme",
+            "valueUrl": "goverment-year.csv#code-list"
+        },
+        {
+            "virtual": true,
+            "name": "virt_type",
+            "required": true,
+            "propertyUrl": "rdf:type",
+            "valueUrl": "skos:Concept"
+        }
+    ],
+    "aboutUrl": "goverment-year.csv#{+uri_identifier}",
+    "primaryKey": "uri_identifier"
+}

--- a/src/test/resources/features/csvw_validation_tests.feature
+++ b/src/test/resources/features/csvw_validation_tests.feature
@@ -194,7 +194,6 @@ Feature: CSVW Validation Tests
 	
 	# manifest-validation#test023
 	# If `true`, sets the `header row count` flag to 1, and if `false` to 0, unless `headerRowCount` is provided, in which case the value provided for the `header` property is ignored.
-  @ignore
   Scenario: manifest-validation#test023 dialect: header=false
     Given I have a CSV file called "csvw/tree-ops.csv"
     And it is stored at the url "https://w3c.github.io/csvw/tests/tree-ops.csv"

--- a/src/test/scala/csvwcheck/ValidatorTest.scala
+++ b/src/test/scala/csvwcheck/ValidatorTest.scala
@@ -250,4 +250,20 @@ class ValidatorTest extends AnyFunSuite {
     set += val2 // Since the hashcode method is overridden in KeyWithContext class val1 is equal to val2
     assert(set.size == 1)
   }
+
+  test(
+    "it should cope with @language properties on strings (Issue #101)"
+  ) {
+    val testCaseFile = new File(s"${csvwExamplesBaseDir}/languagetagbroken101/goverment-year.csv-metadata.json")
+    assert(testCaseFile.exists())
+
+    val validator = new Validator(Some(s"file://${testCaseFile.getAbsolutePath}"))
+    var warningsAndErrors = WarningsAndErrors()
+    val akkaStream =
+      validator.validate().map(wAndE => warningsAndErrors = wAndE)
+    Await.ready(akkaStream.runWith(Sink.ignore), 10.seconds)
+    val errors = warningsAndErrors.errors
+    assert(errors.isEmpty)
+  }
 }
+

--- a/src/test/scala/csvwcheck/models/TableGroupTest.scala
+++ b/src/test/scala/csvwcheck/models/TableGroupTest.scala
@@ -228,9 +228,9 @@ class TableGroupTest extends AnyFunSuite {
     assert(tableGroup.annotations.size === 0)
     assert(warningsAndErrors.warnings.length === 0)
     assert(tableGroup.tables.size === 1)
-    assert(table.columns.length === 10)
+    assert(table.schema.get.columns.length === 10)
     assert(
-      table.columns(0).nullParam === Array("-")
+      table.schema.get.columns(0).nullParam === Array("-")
     ) // should inherit null to all columns - assertion which justifies test name
   }
 
@@ -292,7 +292,7 @@ class TableGroupTest extends AnyFunSuite {
       tableGroup.tables("http://w3c.github.io/csvw/tests/tree-ops.csv")
 
     assert(tableGroup.tables.size === 1)
-    assert(table.columns.length === 5)
+    assert(table.schema.get.columns.length === 5)
   }
 
   test(

--- a/src/test/scala/csvwcheck/models/TableTest.scala
+++ b/src/test/scala/csvwcheck/models/TableTest.scala
@@ -95,21 +95,21 @@ class TableTest extends AnyFunSuite {
 
     assert(table1.url === "http://w3c.github.io/csvw/tests/countries.csv")
     assert(table1.id.get === "http://w3c.github.io/csvw/tests/sample_id_value")
-    assert(table1.columns.length === 4)
+    assert(table1.schema.get.columns.length === 4)
     assert(table1.dialect.get.encoding === "utf-8")
-    assert(table2.foreignKeys.length === 1)
-    assert(table2.foreignKeys(0).localColumns(0).name.get === "countryRef")
+    assert(table2.schema.get.foreignKeys.length === 1)
+    assert(table2.schema.get.foreignKeys(0).localColumns(0).name.get === "countryRef")
     assert(table1.notes.isDefined)
     assert(
       table1.notes.get.elements().asScalaArray(0) === new TextNode(
         "sample value"
       )
     )
-    assert(table1.primaryKey(0).name.get === "countryCode")
-    assert(table1.rowTitleColumns.length === 1)
-    assert(table1.rowTitleColumns(0).name.get === "countryCode")
+    assert(table1.schema.get.primaryKey(0).name.get === "countryCode")
+    assert(table1.schema.get.rowTitleColumns.length === 1)
+    assert(table1.schema.get.rowTitleColumns(0).name.get === "countryCode")
     assert(
-      table1.schemaId.get === "sample_id_value"
+      table1.schema.get.schemaId.get === "sample_id_value"
     )
     assert(table1.suppressOutput === true)
     assert(table1.annotations.isEmpty)


### PR DESCRIPTION
Satisfies issue #101.

I also fixed the `manifest-validation#test023 dialect: header=false` scenario; the schema is not set in this test-case and our code couldn't distinguish between the `tableSchema` being unset and it being set with no columns defined.